### PR TITLE
feat: update all code to support new version of template

### DIFF
--- a/commands/2-create-stack-config-org.sh
+++ b/commands/2-create-stack-config-org.sh
@@ -18,6 +18,7 @@ aws cloudformation create-stack --stack-name Config-StackSetConfigRecorder \
       ParameterKey=StSeParDeliveryChannelName,ParameterValue="<Generated>" \
       ParameterKey=StSeParS3KeyPrefix,ParameterValue=o-xxxxxxx \
       ParameterKey=StSeParFrequency,ParameterValue=24hours \
+      ParameterKey=StSeParRecordingFrequency,ParameterValue=DAILY \
       ParameterKey=StSeParSNS,ParameterValue=false \
       ParameterKey=StSeParTopicArn,ParameterValue="<New Topic>" \
       ParameterKey=StSeParNotificationEmail,ParameterValue="<None>"

--- a/templates/aws-stacksets/EnableAWSConfigForOrganizations.yml
+++ b/templates/aws-stacksets/EnableAWSConfigForOrganizations.yml
@@ -11,6 +11,8 @@ Metadata:
           - IncludeGlobalResourceTypes
           - ResourceTypes
           - ServiceLinkedRoleRegion
+          - RecordingFrequency
+
       - Label:
           default: Delivery Channel Configuration
         Parameters:
@@ -41,6 +43,8 @@ Metadata:
         default: Prefix for the specified Amazon S3 bucket
       Frequency:
         default: Snapshot delivery frequency
+      RecordingFrequency:
+        default: Configuration recorder recording frequency
       SNS:
         default: SNS notifications
       TopicArn:
@@ -102,6 +106,13 @@ Parameters:
       - 6hours
       - 12hours
       - 24hours
+
+  RecordingFrequency:
+    Type: String
+    Description: The frequency with which AWS Config Recorder records configuration changes.
+    AllowedValues:
+      - CONTINUOUS
+      - DAILY
 
   SNS:
     Type: String
@@ -276,6 +287,8 @@ Resources:
       RoleARN:
         Fn::Sub:
           "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig"
+      RecordingMode:
+        RecordingFrequency: !Ref RecordingFrequency
 
   ConfigDeliveryChannel:
     Type: AWS::Config::DeliveryChannel

--- a/templates/custom-templates/2-StackSetConfigOrg.yml
+++ b/templates/custom-templates/2-StackSetConfigOrg.yml
@@ -34,6 +34,7 @@ Metadata:
           - StSeParDeliveryChannelName
           - StSeParS3KeyPrefix
           - StSeParFrequency
+          - StSeParRecordingFrequency
           - StSeParSNS
           - StSeParTopicArn
           - StSeParNotificationEmail
@@ -145,6 +146,12 @@ Parameters:
       - 6hours
       - 12hours
       - 24hours
+  StSeParRecordingFrequency:
+    Type: String
+    Description: StackSet Parameter "RecordingFrequency" - The frequency with which AWS Config Recorder records configuration changes.
+    AllowedValues:
+      - CONTINUOUS
+      - DAILY
   StSeParSNS:
     Type: String
     Default: true
@@ -268,6 +275,8 @@ Resources:
           ParameterValue: !Ref StSeParS3KeyPrefix
         - ParameterKey: Frequency
           ParameterValue: !Ref StSeParFrequency
+        - ParameterKey: RecordingFrequency
+          ParameterValue: !Ref StSeParRecordingFrequency
         - ParameterKey: SNS
           ParameterValue: !Ref StSeParSNS
         - ParameterKey: TopicArn


### PR DESCRIPTION
Update all code to support new version of template "EnableAWSConfigForOrganizations.yml" provided by AWS documentation.

You can look at [AWS Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-sampletemplates.html) in the section "Enable AWS Config with central logging."


